### PR TITLE
Improved fake log records

### DIFF
--- a/analytics-cli/requirements.txt
+++ b/analytics-cli/requirements.txt
@@ -8,3 +8,4 @@ SQLAlchemy
 psycopg2-binary
 python-dateutil
 ua-parser[regex]
+Jinja2

--- a/analytics-cli/setup.cfg
+++ b/analytics-cli/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     psycopg2-binary
     python-dateutil
     ua-parser[regex]
+    Jinja2
 
 [options.packages.find]
 where = src

--- a/analytics-cli/src/georchestra_analytics_cli/access_logs/AccessLogProcessor.py
+++ b/analytics-cli/src/georchestra_analytics_cli/access_logs/AccessLogProcessor.py
@@ -172,7 +172,8 @@ class AccessLogProcessor:
             processed_log_records = list()
             try:
                 while start < stop_time:
-                    for _ in range(random.randint(0, max_rate)):
+                    nb_records = random.randint(0, max_rate)
+                    for _ in range(nb_records):
                         ts = start.timestamp() + random.randint(0, 3600)
                         record = self.log_parser.parse(datetime.fromtimestamp(ts))
                         processed_log_records.append(record)
@@ -180,6 +181,7 @@ class AccessLogProcessor:
                         if processed_log_records and len(processed_log_records) % self.batch_size == 0:
                             logger.debug(f"Upserting {len(processed_log_records)} log records")
                             self.upsert_log_records(session, processed_log_records)
+                    logger.debug(f"[{start.strftime('%m/%d/%Y, %H')} h] Generated {nb_records} log records")
                     start = start + timedelta(hours=1)
 
                 # Last commit at the end of the loop, commit remaining batch

--- a/analytics-cli/src/georchestra_analytics_cli/access_logs/log_parsers/FakeLogGenerator.py
+++ b/analytics-cli/src/georchestra_analytics_cli/access_logs/log_parsers/FakeLogGenerator.py
@@ -3,6 +3,7 @@ import logging
 import random
 from datetime import datetime
 from typing import Any
+from jinja2 import Environment, BaseLoader
 
 from georchestra_analytics_cli.access_logs.log_parsers.BaseLogParser import BaseLogParser
 from georchestra_analytics_cli.config import Config
@@ -17,18 +18,56 @@ fake_data = {
         {"name": "testuser2", "org": "G2F", "roles": ["ROLE_GEOSERVER_G2F", "ROLE_USER"]},
         {"name": "testeditor", "org": "PSC", "roles": ["ROLE_SUPERSET_ADMIN", "ROLE_USER"]},
     ],
+    "layers": [
+        {"name": "Lines_Borders", "ns": "boundaries"},
+        {"name": "boundaries", "ns": "boundaries"},
+        {"name": "mnt_dem", "ns": "basemaps"},
+        {"name": "parc_naturel", "ns": "environment"},
+        {"name": "pvd_points", "ns": "anct"},
+        {"name": "qva", "ns": "anct"},
+        {"name": "zones_revitalisation_rurale", "ns": "anct"},
+        {"name": "centre_tri", "ns": "odema"},
+        {"name": "dechetterie", "ns": "odema"},
+        {"name": "dechetteries", "ns": "smectom"},
+        {"name": "carrieres", "ns": "ademe"},
+        {"name": "isdi", "ns": "ademe"},
+        {"name": "adresse_ban", "ns": "bdtopo"},
+        {"name": "aerodrome", "ns": "bdtopo"},
+
+    ],
     "requests": [
         {
             "app_path": "geoserver",
             "request_method": "GET",
-            "request_path": "/geoserver/boundaries/ows",
-            "request_query_string": "service=wms&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=frontieres_nationales&STYLES=boundaries%3ALines_Borders&CRS=EPSG%3A3857&WIDTH=2304&HEIGHT=1084&BBOX=715133.0164035556%2C6042414.756063141%2C1074822.6263080558%2C6211643.721834183",
+            "request_path": "/geoserver/ows",
+            "request_query_string": "service=wms&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS={{ ns }}%3A{{ name }}&STYLES={{ ns }}%3A{{ name }}&CRS=EPSG%3A3857&WIDTH=2304&HEIGHT=1084&BBOX=715133.0164035556%2C6042414.756063141%2C1074822.6263080558%2C6211643.721834183",
             "response_size": 77735,
         },
         {
             "app_path": "geoserver",
             "request_method": "GET",
-            "request_path": "/geoserver/environment/ows",
+            "request_path": "/geoserver/ows",
+            "request_query_string": "SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&STYLES&LAYERS={{ ns }}%3A{{ name }}&tiled=true&tilesOrigin=-20185.117899999022%2C6097791.5978000015&WIDTH=256&HEIGHT=256&SRS=EPSG%3A3857&BBOX=312735.5839256644%2C5941976.09458765%2C625471.1678513302%2C6254711.678513316",
+            "response_size": 4940,
+        },
+        {
+            "app_path": "geoserver",
+            "request_method": "GET",
+            "request_path": "/geoserver/ows",
+            "request_query_string": "SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&STYLES&LAYERS={{ ns }}%3A{{ name }}&tiled=true&tilesOrigin=-20185.117899999022%2C6097791.5978000015&WIDTH=256&HEIGHT=256&SRS=EPSG%3A3857&BBOX=312735.5839256644%2C5941976.09458765%2C625471.1678513302%2C6254711.678513316",
+            "response_size": 3800,
+        },
+        {
+            "app_path": "geoserver",
+            "request_method": "GET",
+            "request_path": "/geoserver/ows",
+            "request_query_string": "SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&STYLES&LAYERS={{ ns }}%3A{{ name }}&tiled=true&tilesOrigin=-20185.117899999022%2C6097791.5978000015&WIDTH=256&HEIGHT=256&SRS=EPSG%3A3857&BBOX=312735.5839256644%2C5941976.09458765%2C625471.1678513302%2C6254711.678513316",
+            "response_size": 8700,
+        },
+        {
+            "app_path": "geoserver",
+            "request_method": "GET",
+            "request_path": "/geoserver/{{ ns }}/ows",
             "request_query_string": "service=wms&version=1.3.0&request=GetCapabilities",
             "response_size": 19834,
         },
@@ -42,28 +81,59 @@ fake_data = {
         {
             "app_path": "geoserver",
             "request_method": "GET",
-            "request_path": "/geoserver/basemaps/ows",
-            "request_query_string": "VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=mnt_dem&STYLES=&SRS=EPSG:4326&BBOX=5.804821737,46.484411957778,9.808502599,50.108964044022&WIDTH=400&HEIGHT=362&FORMAT=image/jpeg",
+            "request_path": "/geoserver/{{ ns }}/ows",
+            "request_query_string": "VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS={{ name }}&STYLES=&SRS=EPSG:4326&BBOX=5.804821737,46.484411957778,9.808502599,50.108964044022&WIDTH=400&HEIGHT=362&FORMAT=image/jpeg",
             "response_size": 2645,
         },
         {
             "app_path": "geoserver",
             "request_method": "GET",
-            "request_path": "/geoserver/environment/ows",
-            "request_query_string": "VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS=parc_naturel&STYLES=&SRS=EPSG:4326&BBOX=6.3621425628662,47.041770975692,9.1019554138184,49.61293796662&WIDTH=400&HEIGHT=375&FORMAT=image/jpeg",
+            "request_path": "/geoserver/{{ ns }}/ows",
+            "request_query_string": "VERSION=1.1.1&SERVICE=WMS&REQUEST=GetMap&LAYERS={{ name }}&STYLES=&SRS=EPSG:4326&BBOX=6.3621425628662,47.041770975692,9.1019554138184,49.61293796662&WIDTH=400&HEIGHT=375&FORMAT=image/jpeg",
             "response_size": 45005,
         },
         {
             "app_path": "geoserver",
             "request_method": "GET",
-            "request_path": "/geoserver/boundaries/ows",
-            "request_query_string": "service=wms&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=boundaries%3Alimite_crs&STYLES=boundaries%3AContour_CRS_DE&CRS=EPSG%3A3857&WIDTH=1795&HEIGHT=1344&BBOX=838611.299727416%2C5973362.915505013%2C1032192.094065148%2C6118305.861237555",
+            "request_path": "/geoserver/{{ ns }}/ows",
+            "request_query_string": "service=wms&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS={{ ns }}%3A{{ name }}&STYLES={{ ns }}%3A{{ name }}&CRS=EPSG%3A3857&WIDTH=1795&HEIGHT=1344&BBOX=838611.299727416%2C5973362.915505013%2C1032192.094065148%2C6118305.861237555",
             "response_size": 109946,
         },
+        {
+            "app_path": "geoserver",
+            "request_method": "POST",
+            "request_path": "/geoserver/{{ ns }}/wfs",
+            "request_query_string": "service=wfs&VERSION=2.0.0&REQUEST=GetPropertyValue&typeNames={{ ns }}%3A{{ name }}&valueReference=the_geom",
+            "response_size": 2013,
+        },
+        {
+            "app_path": "geoserver",
+            "request_method": "POST",
+            "request_path": "/geoserver/{{ ns }}/wps",
+            "request_query_string": "service=WPS&version=1.0.0&REQUEST=DescribeProcess&IDENTIFIER={{ ns }}%3A{{ name }}",
+            "response_size": 100,
+        },
     ],
-    "status_codes": [200, 200, 200, 200, 200, 200, 200, 200, 404, 501],
+    "status_codes": [200, 200, 200, 200, 200, 200, 200, 200, 404, 501, 503],
 
 }
+
+
+def _apply_template(layer: dict[str, Any], req: dict[str, Any]) -> dict[str, Any]:
+    """
+    The req object is expected to have some values as jinja2 templates. This functions renders the templates, using the
+     values provided in the layer dict.
+    """
+    rendered_req = {}
+    for k, v in req.items():
+        if isinstance(v, str) and "{{" in v: # contains a jinja2 template placeholder
+            if v is not None:
+                template = Environment(loader=BaseLoader()).from_string(v)
+                rendered_value = template.render(**layer)
+                rendered_req[k] = rendered_value
+        else: 
+            rendered_req[k] = v
+    return rendered_req
 
 
 class FakeLogGenerator(BaseLogParser):
@@ -81,23 +151,24 @@ class FakeLogGenerator(BaseLogParser):
     config: Config = None
     hashl = None
 
-    def __init__(self, config: config):
+    def __init__(self, config: Config):
         self.config = config
         # hashlib is used to generate a hashed key identifying the log message so that we can handle duplicates
         self.hashl = hashlib.md5()
         super().__init__(config)
-
 
     def parse(self, date: datetime) -> dict[str, Any]:
         """
         Generate a fake log record for the given date.
         """
         user = random.choice(fake_data["users"])
+        layer = random.choice(fake_data["layers"])
         req = random.choice(fake_data["requests"])
+        req = _apply_template(layer, req)
         log_dict = {
             "ts": date.isoformat(),
             "id": self.generate_req_id(date.isoformat()),
-            "message": f"{date.isoformat()} GET {req.get('request_path')}?{req.get('request_query_string')} {req.get('response_size')}",
+            "message": f"{date.isoformat()} {req.get('request_method')} {req.get('request_path')}?{req.get('request_query_string')} {req.get('response_size')}",
             "app_path": req.get("app_path"),
             "app_name": self.config.what_app_is_it(req.get("app_path")),
             "user_id": user.get("name"),
@@ -106,10 +177,10 @@ class FakeLogGenerator(BaseLogParser):
             "org_name": user.get("org"),
             "roles": user.get("roles"),
             "auth_method": None,
-            "request_method": "GET",
+            "request_method": f"{req.get('request_method')}",
             "request_path": req.get("request_path").lower(),
-            "request_query_string": req.get("request_query_string").lower(),
-            "request_details": split_query_string(req.get("request_query_string").lower()),
+            "request_query_string": req.get('request_query_string').lower(),
+            "request_details": split_query_string(req.get('request_query_string').lower()),
             "response_time": random.randint(50, 2000),
             "response_size": req.get("response_size"),
             "status_code": random.choice(fake_data["status_codes"]),
@@ -125,16 +196,15 @@ class FakeLogGenerator(BaseLogParser):
                 return None
             app_data = lp.collect_information(log_dict.get("request_path", ""), log_dict.get("request_details", {}))
             if app_data is not None:
-                # We replace the request_details dict, instead of simplfy updating it. It allows to drop some values deemed uninteresting/redundant
+                # We replace the request_details dict, instead of simplify updating it. It allows to drop some values deemed uninteresting/redundant
                 # dict_recursive_update(log_dict["request_details"], app_data)
                 log_dict["request_details"] = app_data
         return log_dict
 
-    def generate_req_id(self, msg):
+    def generate_req_id(self, msg) -> str:
         """
         Generate an ID for this log line. Will serve to avoid inserting duplicates. Replaces the span_id that we get
         with OpenTelemetry
         """
         self.hashl.update(msg.encode('utf-8'))
         return self.hashl.hexdigest()[0:12]
-

--- a/helm/analytics/templates/cli/cli-cronjob.yaml
+++ b/helm/analytics/templates/cli/cli-cronjob.yaml
@@ -25,9 +25,17 @@ spec:
             #   - /bin/sh
             #   - -c
             #   - sleep 10000
-            command:
-              - analytics-cli
-              - buffer2db
+            command: ["analytics-cli"]
+            args:
+            {{- if $webapp.fakeRecords.enabled }}
+              - "fake2db"
+              - "--last_n_hours"
+              - {{ $webapp.fakeRecords.coverDurationHours | quote }}
+              - "--rate"
+              - {{ $webapp.fakeRecords.maxRate | quote }}
+            {{- else }}
+              - "buffer2db"
+            {{- end }}
             env:
               - name: TSDB_HOST
                 valueFrom:

--- a/helm/analytics/values.yaml
+++ b/helm/analytics/values.yaml
@@ -129,6 +129,17 @@ vector:
 # Python CLI cronjob
 cli:
   enabled: true
+  fakeRecords:
+    # Enable this if you want to generate fake log records, instead of processing real ones.
+    # Useful for dashboard development.
+    # Beware that when this is active, it will not process the real records, only generate fake ones.
+    enabled: false
+    # This setting defines how many hours before now will be covered. You will want to make it match with the schedule
+    # For instance, with coverDurationHours: 1 and schedule: "01 * * * *", it will generate every hour records for the
+    # last hour (ensuring you don't have any gaps in your data)
+    coverDurationHours: 1
+    # Max number of records per hour.
+    maxRate: 50
   schedule: "0 01 * * *"
   image: georchestra/analytics-cli:latest
   imagePullPolicy: Always
@@ -179,6 +190,5 @@ cli:
           level: DEBUG
         __main__:
           level: DEBUG
-
 
 


### PR DESCRIPTION
Generation of fake logs is useful when working on a dev environment, since there won't be many natural visits to the geOrchestra services.

Generating nice-enough fake records is necessary when working on dashboards, when you want some diversity in the records. This is what this PR tries to achieve.

It also gives the helm chart the capacity to switch the CLI cronjob into fake-log generation