### PR TITLE
Provide basic data privacy feature to cover GDPR (Hopefully enough)

### DIFF
--- a/analytics-cli/config/analytics_cli.yaml
+++ b/analytics-cli/config/analytics_cli.yaml
@@ -10,6 +10,14 @@ performance:
   # Publish in DB by batches
   batch_size: 10000
 
+data_privacy:
+  # Some data privacy policies will require the platform admins to follow some strict rules regarding the personal data.
+  # In Europe for instance, this will be the case with GDPR. While it doesn't per-se forbid the collection of some
+  # personal data if its used is justified and declared, this requires specific processes (declare the collection in
+  # a GDPR registry for one). This is why sensitive data will be excluded *by default*. You can comment them if you
+  # are aware of the implications and taking care of your obligations in that regard.
+  keys_blacklist: []
+
 database:
   drivername: "postgresql"
   host: "localhost"

--- a/analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml
+++ b/analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml
@@ -22,6 +22,17 @@ apps_mapping: { }
 # recognized at all, you will have to be explicit there
 support_multiple_dn: false
 
+data_privacy:
+  # Some data privacy policies will require the platform admins to follow some strict rules regarding the personal data.
+  # In Europe for instance, this will be the case with GDPR. While it doesn't per-se forbid the collection of some
+  # personal data if its used is justified and declared, this requires specific processes (declare the collection in
+  # a GDPR registry for one). This is why sensitive data will be excluded *by default*. You can comment them if you
+  # are aware of the implications and taking care of your obligations in that regard.
+  keys_blacklist:
+    - "user_id"
+    - "user_name"
+    - "client_ip"
+
 database:
   drivername: "postgresql"
   host: "localhost"
@@ -66,8 +77,6 @@ app_processors:
         geojson: "GeoJSON"
         csv: "CSV"
         ooxml: "Excel"
-
-
 
 metrics:
   enabled: false

--- a/analytics-cli/src/georchestra_analytics_cli/config/config.py
+++ b/analytics-cli/src/georchestra_analytics_cli/config/config.py
@@ -89,6 +89,9 @@ class Config:
     def get_batch_size(self) -> int:
         return self.config["performance"].get("batch_size", 1000)
 
+    def get_keys_blacklist(self) -> list[str]:
+        return self.config["data_privacy"].get("keys_blacklist", [])
+
     def get_app_processors_config(self) -> dict[str, Any]:
         return self.config.get("app_processors", {})
 

--- a/analytics-cli/tests/config_files/config.yaml
+++ b/analytics-cli/tests/config_files/config.yaml
@@ -16,6 +16,12 @@ database:
 apps_mapping:
   "/data/": dataapi
 
+data_privacy:
+  keys_blacklist:
+    - "user_id"
+    - "user_name"
+    - "roles"
+
 parsers:
   opentelemetry:
     text_message_parser:

--- a/analytics-cli/tests/config_files/config_multiple_dn.yaml
+++ b/analytics-cli/tests/config_files/config_multiple_dn.yaml
@@ -14,6 +14,10 @@ database:
   password: !ENV "${DB_SECRET:secret}"
 
 support_multiple_dn: true
+
+data_privacy:
+  keys_blacklist: []
+
 apps_mapping:
    "demo.georchestra.org/catalog/": "geonetwork"
    "mapserv.georchestra.org/": "mapserver"

--- a/analytics-cli/tests/test_config.py
+++ b/analytics-cli/tests/test_config.py
@@ -47,3 +47,11 @@ def test_config_app_mapping_multiple_dn():
     assert conf.what_app_is_it("mapserv.georchestra.org/") == "mapserver"
     # This one covers a non-delcared mapping
     assert conf.what_app_is_it("mapproxy.georchestra.org/") == "mapproxy.georchestra.org"
+
+def test_config_keys_blacklist():
+    conf = load_config_from(config_file)
+    assert conf.get_keys_blacklist() == ["user_id", "user_name", "roles"]
+
+def test_config_keys_blacklist_empty():
+    conf = load_config_from(config_multiple_dn)
+    assert conf.get_keys_blacklist() == []


### PR DESCRIPTION

The config file allows to declare a list of keys to exclude when collecting the data. By default, it excludes the keys that would be concerned by GDPR: `user_id`, `user_name`, `client_ip`.

It ensures that platform admins won't unwilfully transgress the GDPR policies. But allows them to still collect personal identifiable data if needed (the responsibility to do so while respecting the GDPR or other data privacy policies is up to them).
It is likely that most platform admins will want to collect some of them, but then, having to turn this out explicitly ensures that they are aware of it and responsible for doing so.

To collect those informations anyway, you can declare an empty list in your config file:
```yaml
# Those are the default values
# data_privacy:
#   keys_blacklist:
#     - "user_id"
#     - "user_name"
#     - "roles"

# This will disable the blacklisting, hence enabling the collection of personal data information
data_privacy:
  keys_blacklist: []
```
