### PR TITLE
improve regexp for CLF-like parsing

### DIFF
--- a/analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml
+++ b/analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml
@@ -63,7 +63,7 @@ parsers:
 
   # This is the config for the CLF-like logs workflow (log files -> Analytics CLI -> TimescaleDB)
   text_message:
-    regex: '^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTIONS|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app_path>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)'
+    regex: '^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|,@\. \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTIONS|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app_path>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)'
     # Default response time unit is ms. If using seconds, uncomment this line
     # response_time_unit: "s"
 

--- a/analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml
+++ b/analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml
@@ -59,11 +59,11 @@ parsers:
       # For instance, see https://docs.georchestra.org/analytics/en/latest/technical_guides/installation/advanced_configurations/gateway_reconcile_netty_logs/
       # If enabled, the regex used for the text parser will be the one provided here.
       enable: false
-      regex: r"^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTION|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app_path>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)"
+      regex: r"^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTIONS|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app_path>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)"
 
   # This is the config for the CLF-like logs workflow (log files -> Analytics CLI -> TimescaleDB)
   text_message:
-    regex: r"^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTION|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app_path>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)"
+    regex: '^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTIONS|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app_path>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)'
     # Default response time unit is ms. If using seconds, uncomment this line
     # response_time_unit: "s"
 


### PR DESCRIPTION
in my testing, if using a raw string with an `r` prefix and double quotes here, it wasn't extrapolated by the python code and used as a string started by `r`.... so don't use the `r` prefix and use single quotes instead, matches the actual lines produced by the s-p and the gateway.

while here, `OPTIONS` is the right HTTP method name, not `OPTION`

i haven't tested/modified the regex string for the opentelemetry parser but maybe it has the same issue.

sidenote: i dunno which file should be used between analytics-cli/config/analytics_cli.yaml and analytics-cli/src/georchestra_analytics_cli/config/analytics_cli.yaml, the first one has less comments and seem to predate the second one.