### PR TITLE
feat(sync-dashboards): assemble db-uri from TSDB_* env vars

### DIFF
--- a/tools/sync_dashboards/README.md
+++ b/tools/sync_dashboards/README.md
@@ -64,9 +64,24 @@ All options can be set via CLI flags or environment variables.
 |------|---------|---------|-------------|
 | `--superset-url` | `SUPERSET_URL` | `http://localhost:8088` | Superset base URL |
 | `--dashboards-dir` | `DASHBOARDS_DIR` | `/dashboards` | Directory containing `.zip` exports |
-| `--db-uri` | `ANALYTICS_DB_URI` | *(none)* | Override `sqlalchemy_uri` in database configs |
+| `--db-uri` | `ANALYTICS_DB_URI` | *(none)* | Override `sqlalchemy_uri` in database configs (see below) |
 | `--force` | | `false` | Import even if the hash hasn't changed |
 | `--verbose` / `-v` | | `false` | Debug logging |
+
+### Database URI
+
+If `--db-uri` / `$ANALYTICS_DB_URI` is not set, the URI is assembled from the
+following env vars (all five must be set):
+
+| Env var | Example |
+|---------|---------|
+| `TSDB_USER` | `tsdb` |
+| `TSDB_PASSWORD` | `password` |
+| `TSDB_HOST` | `timescaledb` |
+| `TSDB_PORT` | `5432` |
+| `TSDB_NAME` | `analytics` |
+
+Result: `postgresql://$TSDB_USER:$TSDB_PASSWORD@$TSDB_HOST:$TSDB_PORT/$TSDB_NAME`
 
 ### geOrchestra auth (default)
 

--- a/tools/sync_dashboards/sync_dashboards.py
+++ b/tools/sync_dashboards/sync_dashboards.py
@@ -28,6 +28,7 @@ Usage (geOrchestra sec-proxy headers):
 Environment variables (fallbacks for CLI options):
     SUPERSET_URL, SUPERSET_USERNAME, SUPERSET_PASSWORD,
     DASHBOARDS_DIR, ANALYTICS_DB_URI,
+    TSDB_USER, TSDB_PASSWORD, TSDB_HOST, TSDB_PORT, TSDB_NAME,
     SEC_USERNAME, SEC_ROLES, SEC_EMAIL
 """
 
@@ -58,6 +59,25 @@ DEFAULT_DASHBOARDS_DIR = "/dashboards"
 def compute_file_hash(filepath: Path) -> str:
     """Return the SHA-256 hex digest of a file."""
     return hashlib.file_digest(open(filepath, "rb"), "sha256").hexdigest()
+
+
+def _default_db_uri() -> str | None:
+    """Resolve the default ``--db-uri`` from environment variables.
+
+    Precedence: ``$ANALYTICS_DB_URI`` wins; otherwise assemble from
+    ``$TSDB_USER`` / ``$TSDB_PASSWORD`` / ``$TSDB_HOST`` / ``$TSDB_PORT`` /
+    ``$TSDB_NAME`` if all are set.
+    """
+    if uri := os.environ.get("ANALYTICS_DB_URI"):
+        return uri
+    keys = ("TSDB_USER", "TSDB_PASSWORD", "TSDB_HOST", "TSDB_PORT", "TSDB_NAME")
+    parts = {k: os.environ.get(k) for k in keys}
+    if all(parts.values()):
+        return (
+            f"postgresql://{parts['TSDB_USER']}:{parts['TSDB_PASSWORD']}"
+            f"@{parts['TSDB_HOST']}:{parts['TSDB_PORT']}/{parts['TSDB_NAME']}"
+        )
+    return None
 
 
 def extract_dashboard_uuids(zip_path: Path) -> list[str]:
@@ -345,9 +365,11 @@ def main():
     )
     parser.add_argument(
         "--db-uri",
-        default=os.environ.get("ANALYTICS_DB_URI"),
+        default=_default_db_uri(),
         help="Override the sqlalchemy_uri in database configs, "
-             "e.g. 'postgresql://tsdb:pwd@host:5432/analytics' (default: $ANALYTICS_DB_URI)",
+             "e.g. 'postgresql://tsdb:pwd@host:5432/analytics' "
+             "(default: $ANALYTICS_DB_URI, or assembled from "
+             "$TSDB_USER/$TSDB_PASSWORD/$TSDB_HOST/$TSDB_PORT/$TSDB_NAME).",
     )
     parser.add_argument(
         "--force", action="store_true",


### PR DESCRIPTION
Falls back to building the sqlalchemy_uri from TSDB_USER / TSDB_PASSWORD / TSDB_HOST / TSDB_PORT / TSDB_NAME when ANALYTICS_DB_URI is not set, so the image can be configured from existing per-field secrets without composing a single URI upstream.

Needed for the helm chart analytics and can be used too in docker-compose project.